### PR TITLE
Validação de CPF

### DIFF
--- a/lib/despachante.ex
+++ b/lib/despachante.ex
@@ -1,17 +1,37 @@
 defmodule Despachante do
   @moduledoc """
-  Biblioteca para validação de documentos brasileiros.
+  Utils for validation, mocking and generation of brazilian document information.
 
-     iex Despachante.valida_cpf("111") == true
+    iex>  Despachante.valid?(:cpf, "081.495.660-23")
+    true
   """
-  def _validate_digit(digits, validate_array, digit) do
-    digits
-    |> Enum.zip_reduce(validate_array, 0, fn left, right, acc -> acc + (left * right) end)
-    |> Kernel.*(10)
-    |> Kernel.rem(11)
-    |> Kernel.==(digit)
+  defp validate_digit(digits, validate_array, digit) do
+    remainder = digits
+                |> Enum.zip_reduce(validate_array, 0, fn left, right, acc -> acc + (left * right) end)
+                |> Kernel.*(10)
+                |> Kernel.rem(11)
+
+    remainder == digit or (remainder == 10 and digit == 0)
   end
 
+  @doc """
+  Function that returns if the required document is valid. 
+
+  Despachante.valid?(document, document_number) where: 
+    document is one of 
+    | :cpf for Cadastro de Pessoa Física (CPF) validation 
+    | :cnpj for Cadastro Nacional de Pessoa Jurídica (CNPJ) validation
+    document_number is the value to be validated 
+
+    iex> Despachante.valid?(:cpf, "825.205.780-25")
+    true 
+
+    iex> Despachante.valid?(:cpf, "39549381030")
+    true 
+
+    iex> Despachante.valid?(:cpf, "946.502.280-25")
+    false
+  """
   def valid?(:cpf, document_number) do
     cpf = Regex.replace(~r/[^0-9]/, document_number, "")
           |> String.split("", trim: true)
@@ -22,11 +42,11 @@ defmodule Despachante do
 
     is_first_digit_valid? = cpf
                             |> Enum.slice(0, 9)
-                            |> _validate_digit(Enum.to_list(10..2), List.first(digits)) 
+                            |> validate_digit(Enum.to_list(10..2), List.first(digits)) 
 
     is_second_digit_valid? = cpf
                             |> Enum.slice(0, 10)
-                            |> _validate_digit(Enum.to_list(11..2), List.last(digits)) 
+                            |> validate_digit(Enum.to_list(11..2), List.last(digits)) 
 
     is_first_digit_valid? and is_second_digit_valid?
   end

--- a/lib/despachante.ex
+++ b/lib/despachante.ex
@@ -4,40 +4,31 @@ defmodule Despachante do
 
      iex Despachante.valida_cpf("111") == true
   """
-
-  @doc """
-  Hello world.
-
-  ## Examples
-
-      iex> Despachante.hello()
-      :world
-
-  """
-  def hello do
-    IO.puts "Olá, Despachante"
+  def _validate_digit(digits, validate_array, digit) do
+    digits
+    |> Enum.zip_reduce(validate_array, 0, fn left, right, acc -> acc + (left * right) end)
+    |> Kernel.*(10)
+    |> Kernel.rem(11)
+    |> Kernel.==(digit)
   end
 
-  def valida_tamanho(documento, tamanho) do 
-    if String.length(documento) == tamanho do
-      documento
-    else
-      raise "Erro: O documento não possui o tamanho correto!"
-    end
+  def valid?(:cpf, document_number) do
+    cpf = Regex.replace(~r/[^0-9]/, document_number, "")
+          |> String.split("", trim: true)
+          |> Enum.map(fn x -> elem(Integer.parse(x), 0) end)
+
+    digits = cpf
+             |> Enum.slice(9, 2)
+
+    is_first_digit_valid? = cpf
+                            |> Enum.slice(0, 9)
+                            |> _validate_digit(Enum.to_list(10..2), List.first(digits)) 
+
+    is_second_digit_valid? = cpf
+                            |> Enum.slice(0, 10)
+                            |> _validate_digit(Enum.to_list(11..2), List.last(digits)) 
+
+    is_first_digit_valid? and is_second_digit_valid?
   end
 
-  def calculo_cpf(cpf) do
-    if String.length(cpf) == 0 do
-      raise "askdjsladjlaskl"
-    end
-    IO.puts cpf
-    restante = String.slice(cpf, 1, 11)
-    calculo_cpf(restante)
-  end
-  
-  def valida_cpf(), do: "CPF Vazio"
-  def valida_cpf(cpf) do
-    cpf_valido = valida_tamanho(cpf, 11)
-    calculo_cpf(cpf_valido)
-   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Despachante.MixProject do
     [
       app: :despachante,
       version: "0.1.0",
-      elixir: "~> 1.12",
+      elixir: "1.13.4",
       start_permanent: Mix.env() == :prod,
       deps: deps()
     ]

--- a/test/despachante_test.exs
+++ b/test/despachante_test.exs
@@ -2,7 +2,7 @@ defmodule DespachanteTest do
   use ExUnit.Case
   doctest Despachante
 
-  test "greets the world" do
-    assert Despachante.hello() == :world
-  end
+   # test "greets the world" do
+   #   assert Despachante.hello() == :world
+   # end
 end


### PR DESCRIPTION
Criei as funções de validação de CPF e os doctests (que não são os testes unitários necessários).

## Como usar no REPL
Para rodar as funções basta entrar com o nvim no projeto e abrir `lib/despachante.ex` e então rodar.
```
:vs t
:term iex -S mix
```
Isso vai abrir o REPL na janela do nvim, ali é possivel chamar qualquer função criada e testar seu retorno.

## Rodando os doctests
Para rodar os doctests basta rodar o comando na raiz do projeto:
```
$ mix test
```
ou no nvim
```
:term mix test
```