### PR TITLE
add validacao sobre tamanho e CPFs inválidos

### DIFF
--- a/lib/despachante.ex
+++ b/lib/despachante.ex
@@ -14,6 +14,13 @@ defmodule Despachante do
     remainder == digit or (remainder == 10 and digit == 0)
   end
 
+  defp validate_edge_cases(document, size) do
+    has_correct_length = String.length(document) == size
+    has_same_digits = Regex.match?(~r/^(\d)\1+$/, document)
+
+    has_correct_length and not has_same_digits
+  end
+
   @doc """
   Function that returns if the required document is valid. 
 
@@ -33,22 +40,26 @@ defmodule Despachante do
     false
   """
   def valid?(:cpf, document_number) do
-    cpf = Regex.replace(~r/[^0-9]/, document_number, "")
+    clean_document = Regex.replace(~r/[^0-9]/, document_number, "")
+    
+    cpf = clean_document
           |> String.split("", trim: true)
           |> Enum.map(fn x -> elem(Integer.parse(x), 0) end)
 
     digits = cpf
              |> Enum.slice(9, 2)
 
-    is_first_digit_valid? = cpf
+    first_digit_valid = cpf
                             |> Enum.slice(0, 9)
                             |> validate_digit(Enum.to_list(10..2), List.first(digits)) 
 
-    is_second_digit_valid? = cpf
+    second_digit_valid = cpf
                             |> Enum.slice(0, 10)
                             |> validate_digit(Enum.to_list(11..2), List.last(digits)) 
 
-    is_first_digit_valid? and is_second_digit_valid?
+    edge_cases_validated = validate_edge_cases(clean_document, 11)
+
+    first_digit_valid and second_digit_valid and edge_cases_validated
   end
 
 end

--- a/test/cpf_test.exs
+++ b/test/cpf_test.exs
@@ -40,5 +40,21 @@ defmodule CpfTest do
     assert Despachante.valid?(:cpf, "993.752.917-96") == false
     assert Despachante.valid?(:cpf, "992.244.554-57") == false
   end
+
+  test "know invalid cpfs should be false" do
+    assert Despachante.valid?(:cpf, "111.111.111-11") == false
+    assert Despachante.valid?(:cpf, "22222222222") == false
+    assert Despachante.valid?(:cpf, "123.456.789-10") == false
+    assert Despachante.valid?(:cpf, "99999999999") == false
+    assert Despachante.valid?(:cpf, "000.000.000-00") == false
+  end
+
+  test "values with more than 11 chars should be false" do
+    assert Despachante.valid?(:cpf, "1") == false
+    assert Despachante.valid?(:cpf, "973.123.773.940") == false
+    assert Despachante.valid?(:cpf, "6575862934") == false
+    assert Despachante.valid?(:cpf, "") == false
+    assert Despachante.valid?(:cpf, "462.565.337-12000000") == false
+  end
   
 end


### PR DESCRIPTION
Adicionei as validações de CPF #5 e #6 que ainda faltavam.

## Como usar no REPL
Para rodar as funções basta entrar com o nvim no projeto e abrir `lib/despachante.ex` e então rodar.
```
:vs t
:term iex -S mix
```
Isso vai abrir o REPL na janela do nvim, ali é possivel chamar qualquer função criada e testar seu retorno.

## Rodando os doctests
Para rodar os doctests basta rodar o comando na raiz do projeto:
```
$ mix test
```
ou no nvim
```
:term mix test
```